### PR TITLE
put minitrace in the build_interface link library (#874)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ target_link_libraries(${BTCPP_LIBRARY}
         Threads::Threads
         ${CMAKE_DL_LIBS}
         $<BUILD_INTERFACE:foonathan::lexy>
-        minitrace
+        $<BUILD_INTERFACE:minitrace>
     PUBLIC
         ${BTCPP_EXTRA_LIBRARIES}
 )


### PR DESCRIPTION
fixes the cmake export set when building behavior tree on standard cmake: CMake Error: install(EXPORT "behaviortree_cppTargets" ...) includes target "behaviortree_cpp" which requires target "minitrace" that is not in any export set.

<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->
